### PR TITLE
Support for splitting behaviors up into batches

### DIFF
--- a/src/main/groovy/org/easyb/batches/BatchManager.groovy
+++ b/src/main/groovy/org/easyb/batches/BatchManager.groovy
@@ -1,0 +1,34 @@
+package org.easyb.batches
+
+import java.util.concurrent.atomic.AtomicInteger
+import org.easyb.domain.Behavior
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Manage running batches of behaviors.
+ * For example, running every 1st behavior out of 10.
+ */
+class BatchManager {
+    def behaviorCount = new AtomicInteger(0);
+    def registeredBehaviors = new CopyOnWriteArrayList<Behavior>();
+    def batchCount;
+    def batchNumber;
+
+    def BatchManager(Integer batchCount, Integer batchNumber) {
+        this.batchCount = batchCount
+        this.batchNumber = batchNumber
+    }
+
+    def getCurrentBehaviorNumber() {
+        behaviorCount.get();
+    }
+    
+    public boolean shouldExecute (def someBehavior) {
+        if (batchCount) {
+            def currentCount = behaviorCount.incrementAndGet()
+            (currentCount % batchCount == (batchNumber % batchCount))
+        } else {
+            true
+        }
+    }
+}

--- a/src/main/java/org/easyb/Configuration.java
+++ b/src/main/java/org/easyb/Configuration.java
@@ -24,6 +24,8 @@ public class Configuration {
   private String junitRootPackage;
   private int maxThreads = 10;
   private long parallelTimeoutInSeconds = 60;
+  private Integer batchCount = 0;
+  private Integer batchNumber = 0;
 
   public Configuration() {
     this(new String[]{}, Collections.<ReportWriter>emptyList());
@@ -68,11 +70,16 @@ public class Configuration {
   public Configuration(final String[] filePaths, final List<ReportWriter> configuredReports,
                        final boolean stackTraceOn, final boolean filteredStackTraceOn,
                        final String extendedStoryClassName, final boolean parallel, final boolean isFailureFile,
-                       final String failureFile, final String[] tags, String rootPackage, Integer parallelMaxThreads, Long parallelTimeout) {
+                       final String failureFile, final String[] tags, String rootPackage,
+                       Integer parallelMaxThreads, Long parallelTimeout,
+                       Integer batchCount, Integer batchNumber) {
     this(filePaths, configuredReports, stackTraceOn, filteredStackTraceOn,
          extendedStoryClassName, parallel, isFailureFile, failureFile);
     this.tags = tags;
     this.junitRootPackage = rootPackage;
+
+    this.batchCount = batchCount;
+    this.batchNumber = batchNumber;
 
     if (parallelMaxThreads != null) {
       this.maxThreads = parallelMaxThreads.intValue();
@@ -147,5 +154,13 @@ public class Configuration {
 
   public void setMaxThreads(int maxThreads) {
     this.maxThreads = maxThreads;
+  }
+
+  public Integer getBatchCount() {
+    return batchCount;
+  }
+
+  public Integer getBatchNumber() {
+    return batchNumber;
   }
 }

--- a/src/main/java/org/easyb/ConsoleConfigurator.java
+++ b/src/main/java/org/easyb/ConsoleConfigurator.java
@@ -50,6 +50,11 @@ public class ConsoleConfigurator {
     private static final String TAG = "tags";
     private static final String TAG_DESCRIPTION = "run behaviors with tag marker";
 
+    private static final String BATCH_COUNT = "batchCount";
+    private static final String BATCH_COUNT_DESCRIPTION = "The total number of batches these tests are being split up into";
+
+    private static final String BATCH_NUMBER = "batchNumber";
+    private static final String BATCH_NUMBER_DESCRIPTION = "The number of the current batch if these tests are being split up into";
 
     public Configuration configure(final String[] args) {
         final Options options = getOptionsForMain();
@@ -66,7 +71,9 @@ public class ConsoleConfigurator {
                     isFailureFile(commandLine), commandLine.getOptionValue(FAILURE_BEHAVIOR_FILE),
                     getTags(commandLine), getRootPackage(commandLine),
                     commandLine.hasOption(PARALLEL_MAX_THREADS) ? Integer.parseInt(commandLine.getOptionValue(PARALLEL_MAX_THREADS)) : null,
-                    commandLine.hasOption(PARALLEL_TIMEOUT_IN_SECONDS) ? Long.parseLong(commandLine.getOptionValue(PARALLEL_TIMEOUT_IN_SECONDS)) : null);
+                    commandLine.hasOption(PARALLEL_TIMEOUT_IN_SECONDS) ? Long.parseLong(commandLine.getOptionValue(PARALLEL_TIMEOUT_IN_SECONDS)) : null,
+                    commandLine.hasOption(BATCH_COUNT) ? Integer.parseInt(commandLine.getOptionValue(BATCH_COUNT)) : null,
+                    commandLine.hasOption(BATCH_NUMBER) ? Integer.parseInt(commandLine.getOptionValue(BATCH_NUMBER)) : null);
 
         } catch (IllegalArgumentException iae) {
             System.out.println(iae.getMessage());
@@ -204,6 +211,8 @@ public class ConsoleConfigurator {
         options.addOption(withDescription(FAILURE_BEHAVIOR_FILE_DESCRIPTION).hasOptionalArg().create(FAILURE_BEHAVIOR_FILE));
         options.addOption(withDescription(TAG_DESCRIPTION).hasOptionalArg().create(TAG));
         options.addOption(withDescription(JUNIT_ROOT_DESCRIPTION).hasOptionalArg().create(JUNIT_ROOT_PACKAGE));
+        options.addOption(withDescription(BATCH_COUNT_DESCRIPTION).hasOptionalArg().create(BATCH_COUNT));
+        options.addOption(withDescription(BATCH_NUMBER_DESCRIPTION).hasOptionalArg().create(BATCH_NUMBER));
 
         return options;
     }

--- a/src/main/java/org/easyb/RunnableBehavior.java
+++ b/src/main/java/org/easyb/RunnableBehavior.java
@@ -2,23 +2,31 @@ package org.easyb;
 
 import java.io.IOException;
 
+import org.easyb.batches.BatchManager;
 import org.easyb.domain.Behavior;
-import org.easyb.listener.BroadcastListener;
 
 public class RunnableBehavior implements Runnable {
     private Behavior behavior;
     private Exception failure;
+    private BatchManager batchManager;
 
-    public RunnableBehavior(Behavior behavior) {
+    public RunnableBehavior(Behavior behavior, BatchManager batchManager) {
         this.behavior = behavior;
+        this.batchManager = batchManager;
     }
 
     public void run() {
         try {
-            behavior.execute();
+            if (shouldExecute(behavior)) {
+                behavior.execute();
+            }
         } catch (IOException e) {
             failure = e;
         }
+    }
+
+    private boolean shouldExecute(Behavior behavior) {
+        return batchManager.shouldExecute(behavior);
     }
 
     public boolean isFailed() {

--- a/src/test/groovy/org/easyb/batches/BatchExecution.specification
+++ b/src/test/groovy/org/easyb/batches/BatchExecution.specification
@@ -1,0 +1,102 @@
+import org.easyb.batches.BatchManager
+import org.easyb.domain.Behavior
+
+it "should say to execute a behavior by default", {
+    batchManager = new BatchManager(null, null);
+
+    def someBehavior = [] as Behavior;
+
+    def result = batchManager.shouldExecute(someBehavior)
+
+    result.shouldBe true
+}
+
+it "should say to execute all behaviors by default", {
+    batchManager = new BatchManager(null, null);
+
+    def someBehavior = [] as Behavior;
+    def someOtherBehavior = [] as Behavior;
+
+    batchManager.shouldExecute(someBehavior).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior).shouldBe true
+}
+
+it "should only execute every nth behavior if batching system properties defined", {
+
+    someBehavior = [] as Behavior;
+    someOtherBehavior2 = [] as Behavior;
+    someOtherBehavior3 = [] as Behavior;
+    someOtherBehavior4 = [] as Behavior;
+    someOtherBehavior5 = [] as Behavior;
+
+    batchManager = new BatchManager(5,1);
+
+    batchManager.shouldExecute(someBehavior).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior2).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior3).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior4).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior5).shouldBe false
+}
+
+
+it "should only execute every nth behavior for larger sets of behaviors", {
+
+    someBehavior = [] as Behavior;
+    someOtherBehavior2 = [] as Behavior;
+    someOtherBehavior3 = [] as Behavior;
+    someOtherBehavior4 = [] as Behavior;
+    someOtherBehavior5 = [] as Behavior;
+    someOtherBehavior6 = [] as Behavior;
+    someOtherBehavior7 = [] as Behavior;
+    someOtherBehavior8 = [] as Behavior;
+    someOtherBehavior9 = [] as Behavior;
+    someOtherBehavior10 = [] as Behavior;
+
+    batchManager = new BatchManager(3,2);
+
+    batchManager.shouldExecute(someBehavior).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior2).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior3).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior4).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior5).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior6).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior7).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior8).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior9).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior10).shouldBe false
+
+}
+
+it "should only execute every nth behavior for larger sets of behaviors and execution at the end", {
+
+    someBehavior = [] as Behavior;
+    someOtherBehavior2 = [] as Behavior;
+    someOtherBehavior3 = [] as Behavior;
+    someOtherBehavior4 = [] as Behavior;
+    someOtherBehavior5 = [] as Behavior;
+    someOtherBehavior6 = [] as Behavior;
+    someOtherBehavior7 = [] as Behavior;
+    someOtherBehavior8 = [] as Behavior;
+    someOtherBehavior9 = [] as Behavior;
+    someOtherBehavior10 = [] as Behavior;
+
+    batchManager = new BatchManager(3,1);
+
+    batchManager.shouldExecute(someBehavior).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior2).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior3).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior4).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior5).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior6).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior7).shouldBe true
+    batchManager.shouldExecute(someOtherBehavior8).shouldBe false
+    batchManager.shouldExecute(someOtherBehavior9).shouldBe false
+
+    batchManager.shouldExecute(someOtherBehavior10).shouldBe true
+
+}


### PR DESCRIPTION
Allows you to run only every nth behavior. This lets you dispatch the behaviors across several machines more easily. To do this, you specify two command-line properties:
    easyb.batch.count: The total number of batches to split the behaviors into, and
    easyb.batch.number: The number of the batch to be run during this test run.

So to run every 2nd behavior out of 5, you would do something like:

mvn test -Deasyb.batch.number=2 -Deasyb.batch.count=5
